### PR TITLE
Fix output files not updating

### DIFF
--- a/src/extension/tasks/terminal.ts
+++ b/src/extension/tasks/terminal.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import {Project, type Projects} from '../projects/index.js';
+import type {Project, Projects} from '../projects/index.js';
 import {encodeText} from '../util.js';
 
 import {BaseTaskProvider} from './base.js';
@@ -186,15 +186,9 @@ export class TaskTerminal<WorkerOptions> implements vscode.Pseudoterminal {
     }
 
     private async execute(): Promise<void> {
-        let project: Project;
-        try {
-            // Load EDA project
-            project = await Project.load(
-                this.projects,
-                this.definition.uri || vscode.Uri.joinPath(this.folder.uri, this.definition.project)
-            );
-        } catch (err) {
-            await this.error(err);
+        const project = this.projects.getCurrent();
+        if (!project) {
+            await this.error(new Error('No current project!'));
             return;
         }
 


### PR DESCRIPTION
Previously, the terminal would create a new Project instance when executing a task, causing the task's output files to be added to this instance. However, the output file tree - when asked to refresh - would base its contents on the current project, which is a different instance. For this reason, the output file tree was not always updated correctly.

I can't think of any cases where simply taking the current project would be an issue, but if it is, we can also loop through all projects and match them against the paths we are given.

Fixes #22.