### PR TITLE
Show early warning if project has no input files

### DIFF
--- a/src/extension/tasks/yosys.ts
+++ b/src/extension/tasks/yosys.ts
@@ -29,6 +29,10 @@ export abstract class BaseYosysTerminalTask extends TerminalTask<YosysWorkerOpti
     }
 
     getWorkerOptions(project: Project, targetId: string): YosysWorkerOptions {
+        if (project.getInputFiles().length === 0) {
+            throw new Error('Cannot synthesize project: no input files!');
+        }
+
         return getYosysWorkerOptions(project, targetId);
     }
 


### PR DESCRIPTION
This change makes it so that the user will be shown an error in the terminal if they try to use Yosys without any input files, as doing so would cause weird errors in other places due to the tool output being broken.