### PR TITLE
Fix nextpnr for non-ecp5 architectures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@yowasp/nextpnr-ice40": "^0.7.187-dev.514",
                 "@yowasp/yosys": "^0.38.21-dev.654",
                 "digitaljs": "github:EDAcation/digitaljs#next",
-                "edacation": "github:EDAcation/edacation#feat/output-file-config",
+                "edacation": "^0.3.3",
                 "nextpnr": "^0.4.15",
                 "nextpnr-viewer": "^0.6.1",
                 "os-browserify": "^0.3.0",
@@ -2119,9 +2119,9 @@
             }
         },
         "node_modules/edacation": {
-            "version": "0.3.0",
-            "resolved": "git+ssh://git@github.com/EDAcation/edacation.git#271b90d0ac35002f1b250f1401fc2d6f1c330259",
-            "license": "MIT",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/edacation/-/edacation-0.3.3.tgz",
+            "integrity": "sha512-wJv3xnxvyyzuG5Y8gmBeW/qkRMliVif0idrjX4qKd5OqOpsYdFRjxLQ9z4x7yvDTRpaiPy1pPf1djYfiUeyQPQ==",
             "dependencies": {
                 "@types/node": "^20.11.0",
                 "@types/yargs": "^17.0.32",

--- a/package.json
+++ b/package.json
@@ -360,7 +360,7 @@
         "@yowasp/nextpnr-ice40": "^0.7.187-dev.514",
         "@yowasp/yosys": "^0.38.21-dev.654",
         "digitaljs": "github:EDAcation/digitaljs#next",
-        "edacation": "github:EDAcation/edacation#feat/output-file-config",
+        "edacation": "^0.3.3",
         "nextpnr": "^0.4.15",
         "nextpnr-viewer": "^0.6.1",
         "os-browserify": "^0.3.0",


### PR DESCRIPTION
Related:
- https://github.com/EDAcation/edacation/pull/8
- https://github.com/EDAcation/edacation/pull/9