### PR TITLE
views: Do not unload when navigating away

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -22,7 +22,11 @@ export const activate = async (context: vscode.ExtensionContext) => {
     // Register custom editors
     for (const editorType of Object.values(editors)) {
         const editor = new editorType(context, projects);
-        context.subscriptions.push(vscode.window.registerCustomEditorProvider(editorType.getViewType(), editor));
+        context.subscriptions.push(
+            vscode.window.registerCustomEditorProvider(editorType.getViewType(), editor, {
+                webviewOptions: {retainContextWhenHidden: true}
+            })
+        );
     }
 
     // Register task providers


### PR DESCRIPTION
Keeps views (digitaljs, stats, nextpnr viewers) loaded in memory as long as their tab is open. This prevents them from reloading when navigating back and forth between tabs, which can be quite costly for some views.