### PR TITLE
stats: avoid dropdown cutoff

### DIFF
--- a/src/views/digitaljs/src/viewers/stats/index.ts
+++ b/src/views/digitaljs/src/viewers/stats/index.ts
@@ -95,7 +95,10 @@ export class StatsViewer extends BaseViewer<YosysStats> {
         header.textContent = 'Module Statistics';
         this.root.appendChild(header);
 
-        this.root.appendChild(this.tabsContainer.element);
+        const tabsElem = this.tabsContainer.element;
+        tabsElem.style.height = '100%';
+
+        this.root.appendChild(tabsElem);
         this.tabsContainer.render();
     }
 }


### PR DESCRIPTION
The dropdown will only render a scrollbar if it threatens to overflow outside the viewport, so if we extend the tab container all the way to the bottom it shouldn't cut the dropdown off anymore.