### PR TITLE
digitaljs: embedded subcircuits get blue outline

### DIFF
--- a/src/views/digitaljs/src/viewers/diagram/index.ts
+++ b/src/views/digitaljs/src/viewers/diagram/index.ts
@@ -77,6 +77,7 @@ export class DiagramViewer extends BaseViewer<YosysRTL> {
             }
             cellAttrs[cellName] = {body: {fill: group.color}};
         }
+        cellAttrs['Subcircuit'] = {body: {stroke: 'blue'}};
 
         // Initialize circuit
         const circuit = new Circuit(digitalJs, {subcircuitButtons: this.subCircuitButtons, cellAttributes: cellAttrs});


### PR DESCRIPTION
![image](https://github.com/EDAcation/vscode-edacation/assets/32306794/160b881f-ab5f-4616-baf8-274171a1d61e)
