### PR TITLE
actions: Add target selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -324,7 +324,7 @@
                 {
                     "id": "edacation-actions",
                     "name": "Actions",
-                    "_todo_type": "webview"
+                    "type": "webview"
                 }
             ]
         },
@@ -341,10 +341,6 @@
             {
                 "view": "edacation-projects",
                 "contents": "No EDA project are open.\n[New Project](command:edacation.newProject)\n[Open Project](command:edacation.openProject)\nTo learn more about how to use EDA projects [read the documentation](https://github.com/EDAcation/vscode-edacation)."
-            },
-            {
-                "view": "edacation-actions",
-                "contents": "[Open Configuration](command:edacation.openProjectConfiguration)\n[Show RTL](command:edacation.runRTL)\n[Synthesize using Yosys](command:edacation.runYosys)\n[Place and Route using nextpnr](command:edacation.runNextpnr)\n"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -273,36 +273,51 @@
             {
                 "type": "rtl",
                 "required": [
-                    "project"
+                    "project",
+                    "targetId"
                 ],
                 "properties": {
                     "project": {
                         "type": "string",
                         "description": "Path of the EDA project."
+                    },
+                    "targetId": {
+                        "type": "string",
+                        "description": "ID of the target to execute this task on."
                     }
                 }
             },
             {
                 "type": "yosys",
                 "required": [
-                    "project"
+                    "project",
+                    "targetId"
                 ],
                 "properties": {
                     "project": {
                         "type": "string",
                         "description": "Path of the EDA project."
+                    },
+                    "targetId": {
+                        "type": "string",
+                        "description": "ID of the target to execute this task on."
                     }
                 }
             },
             {
                 "type": "nextpnr",
                 "required": [
-                    "project"
+                    "project",
+                    "targetId"
                 ],
                 "properties": {
                     "project": {
                         "type": "string",
                         "description": "Path of the EDA project."
+                    },
+                    "targetId": {
+                        "type": "string",
+                        "description": "ID of the target to execute this task on."
                     }
                 }
             }

--- a/src/extension/tasks/task.ts
+++ b/src/extension/tasks/task.ts
@@ -9,7 +9,7 @@ import {ToolProvider} from './toolprovider.js';
 
 export interface TaskDefinition extends vscode.TaskDefinition {
     project: string;
-    targetId?: string;
+    targetId: string;
     uri?: vscode.Uri;
 }
 

--- a/src/extension/tasks/terminal.ts
+++ b/src/extension/tasks/terminal.ts
@@ -216,6 +216,12 @@ export class TaskTerminal<WorkerOptions extends _WorkerOptions> implements vscod
             }
         }
 
+        const projectConfig = this.curProject.getConfiguration();
+        if (projectConfig.targets.length === 0) {
+            await this.error(new Error('The current project has no targets defined!'));
+            return;
+        }
+
         if (this.tasks.length === 0 || prevExitCode !== 0) {
             this.curJob = null;
             this.curProject = null;
@@ -226,7 +232,7 @@ export class TaskTerminal<WorkerOptions extends _WorkerOptions> implements vscod
 
         this.curJob = {
             task: this.tasks[0],
-            targetId: this.definition.targetId ?? this.curProject.getConfiguration().targets[0].id
+            targetId: this.definition.targetId ?? projectConfig.targets[0].id
         };
         this.tasks.splice(0, 1);
 

--- a/src/extension/tasks/terminal.ts
+++ b/src/extension/tasks/terminal.ts
@@ -1,7 +1,7 @@
 import {type WorkerOptions as _WorkerOptions} from 'edacation';
 import * as vscode from 'vscode';
 
-import type {Project, Projects} from '../projects/index.js';
+import {Project, type Projects} from '../projects/index.js';
 import {encodeText, ensureEndOfLine} from '../util.js';
 
 import {BaseTaskProvider} from './base.js';
@@ -53,6 +53,7 @@ export abstract class TaskProvider extends BaseTaskProvider {
             task.scope,
             task.definition.uri as vscode.Uri,
             task.definition.project as string,
+            task.definition.targetId as string,
             task.definition as TaskDefinition
         );
     }
@@ -78,7 +79,14 @@ export abstract class TaskProvider extends BaseTaskProvider {
         for (const folder of vscode.workspace.workspaceFolders) {
             const paths = await vscode.workspace.findFiles(PROJECT_PATTERN);
             for (const path of paths) {
-                tasks.push(this.getTask(folder, path, vscode.workspace.asRelativePath(path.fsPath, false)));
+                const project = await Project.load(this.projects, path);
+                const targets = project.getConfiguration().targets;
+
+                for (const target of targets) {
+                    tasks.push(
+                        this.getTask(folder, path, vscode.workspace.asRelativePath(path.fsPath, false), target.id)
+                    );
+                }
             }
         }
 
@@ -89,11 +97,13 @@ export abstract class TaskProvider extends BaseTaskProvider {
         folder: vscode.WorkspaceFolder,
         uri: vscode.Uri,
         project: string,
-        additionalDefinition?: TaskDefinition
+        targetId: string,
+        additionalDefinition?: Partial<TaskDefinition>
     ): vscode.Task {
         const definition: TaskDefinition = {
             type: this.getTaskType(),
             project,
+            targetId,
             uri,
 
             ...additionalDefinition
@@ -235,6 +245,8 @@ export class TaskTerminal<WorkerOptions extends _WorkerOptions> implements vscod
             targetId: this.definition.targetId ?? projectConfig.targets[0].id
         };
         this.tasks.splice(0, 1);
+
+        this.println(`Executing task for target "${this.definition.targetId}"`);
 
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         this.curJob.task.onMessage(this.handleMessage.bind(this, this.curJob));

--- a/src/extension/types.ts
+++ b/src/extension/types.ts
@@ -29,6 +29,7 @@ interface ViewMessageChange {
 interface ViewMessageCommand {
     type: 'command';
     command: string;
+    args?: [];
 }
 
 interface ViewMessageRequestSave {

--- a/src/extension/webviews/actions.ts
+++ b/src/extension/webviews/actions.ts
@@ -60,7 +60,7 @@ export class ActionsProvider extends BaseWebviewViewProvider {
                 });
             }
         } else if (message.type === 'command') {
-            await vscode.commands.executeCommand(message.command);
+            await vscode.commands.executeCommand(message.command, ...(message.args ?? []));
         }
     }
 }

--- a/src/extension/webviews/actions.ts
+++ b/src/extension/webviews/actions.ts
@@ -24,16 +24,22 @@ export class ActionsProvider extends BaseWebviewViewProvider {
         };
     }
 
-    public resolveWebviewView(
+    public async resolveWebviewView(
         webviewView: vscode.WebviewView,
         context: vscode.WebviewViewResolveContext<unknown>,
         token: vscode.CancellationToken
-    ): void | Thenable<void> {
+    ): Promise<void> {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         super.resolveWebviewView(webviewView, context, token);
 
-        // TODO: subscribe to project change
-        // this.projects.getProjectEmitter().event.
+        this.projects.getProjectEmitter().event((_changed) => {
+            const project = this.projects.getCurrent();
+
+            void webviewView.webview.postMessage({
+                type: 'project',
+                project: project ? Project.serialize(project) : undefined
+            });
+        });
     }
 
     protected async onDidReceiveMessage(webview: vscode.Webview, message: ViewMessage): Promise<void> {

--- a/src/views/actions/src/App.vue
+++ b/src/views/actions/src/App.vue
@@ -3,14 +3,14 @@ import {provideVSCodeDesignSystem, vsCodeButton, vsCodeDropdown, vsCodeOption} f
 
 import {vscode} from '../../vscode';
 
-import EDAPlaceholder from './components/EDAPlaceholder.vue';
+import EDAProjectActions from './components/EDAProjectActions.vue';
 import {state} from './state';
 
 provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeDropdown(), vsCodeOption());
 
 export default {
     components: {
-        EDAPlaceholder
+        EDAProjectActions
     },
     data() {
         return {
@@ -42,7 +42,7 @@ export default {
 
 <template>
     <main>
-        <EDAPlaceholder />
+        <EDAProjectActions />
     </main>
 </template>
 

--- a/src/views/actions/src/App.vue
+++ b/src/views/actions/src/App.vue
@@ -1,12 +1,12 @@
 <script lang="ts">
-import {provideVSCodeDesignSystem, vsCodeButton, vsCodeDropdown, vsCodeOption} from '@vscode/webview-ui-toolkit';
+import {provideVSCodeDesignSystem, vsCodeButton, vsCodeDivider, vsCodeDropdown, vsCodeOption} from '@vscode/webview-ui-toolkit';
 
 import {vscode} from '../../vscode';
 
 import EDAProjectActions from './components/EDAProjectActions.vue';
 import {state} from './state';
 
-provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeDropdown(), vsCodeOption());
+provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeDropdown(), vsCodeOption(), vsCodeDivider());
 
 export default {
     components: {

--- a/src/views/actions/src/components/EDAProjectActions.vue
+++ b/src/views/actions/src/components/EDAProjectActions.vue
@@ -14,29 +14,23 @@ export default defineComponent({
     },
     methods: {
         executeCommand(command: string) {
-            vscode.vscode.postMessage(command);
+            vscode.vscode.postMessage({
+                type: 'command',
+                command: `edacation.${command}`
+            });
         },
-
-        something() {
-            if (globalState.project) {
-                //I wanted to use the OpenProjectCommand that is defined in project.ts but this isn't working out
-                //vscode.commands.executeCommand('vscode.openWith', globalState.project.OpenProjectCommand, ProjectEditor.getViewType());
-            }
-        }
     }
 });
 </script>
 
 <template>
     <div style="flex-direction: row; align-items: stretch">
-        <vscode-button style="margin: 0.5rem" @click="executeCommand('openProjectConfiguration')"
-            >Open Project Configuration</vscode-button
-        >
+        <vscode-button style="margin: 0.5rem" @click="executeCommand('openProjectConfiguration')">
+            Open Project Configuration
+        </vscode-button>
         <vscode-button style="margin: 0.5rem" @click="executeCommand('runRTL')">Show RTL</vscode-button>
         <vscode-button style="margin: 0.5rem" @click="executeCommand('runYosys')">Synthesize using Yosys</vscode-button>
-        <vscode-button style="margin: 0.5rem" @click="executeCommand('runNextpnr')"
-            >Place and Route using nextpnr</vscode-button
-        >
+        <vscode-button style="margin: 0.5rem" @click="executeCommand('runNextpnr')">Place and Route using nextpnr</vscode-button>
     </div>
 </template>
 

--- a/src/views/actions/src/components/EDAProjectActions.vue
+++ b/src/views/actions/src/components/EDAProjectActions.vue
@@ -16,14 +16,22 @@ export default defineComponent({
         };
     },
     methods: {
-        executeCommand(command: string) {
+        executeCommand(command: string, ...args: unknown[]) {
             console.log(this.selectedTarget);
 
             vscode.vscode.postMessage({
                 type: 'command',
-                command: `edacation.${command}`
+                command: `edacation.${command}`,
+                args: args
             });
         },
+
+        executeTargetCommand(command: string) {
+            if (!this.selectedTarget) {
+                return this.executeCommand(command);
+            }
+            return this.executeCommand(command, this.selectedTarget.id)
+        }
     },
     computed: {
         targets(): TargetConfiguration[] {
@@ -47,9 +55,9 @@ export default defineComponent({
             <vscode-divider></vscode-divider>
             <EDATargetSelector v-if="targets.length > 1"/>
 
-            <vscode-button @click="executeCommand('runRTL')">Show RTL</vscode-button>
-            <vscode-button @click="executeCommand('runYosys')">Synthesize using Yosys</vscode-button>
-            <vscode-button @click="executeCommand('runNextpnr')">Place and Route using nextpnr</vscode-button>
+            <vscode-button @click="executeTargetCommand('runRTL')">Show RTL</vscode-button>
+            <vscode-button @click="executeTargetCommand('runYosys')">Synthesize using Yosys</vscode-button>
+            <vscode-button @click="executeTargetCommand('runNextpnr')">Place and Route using nextpnr</vscode-button>
         </template>
     </div>
 </template>

--- a/src/views/actions/src/components/EDAProjectActions.vue
+++ b/src/views/actions/src/components/EDAProjectActions.vue
@@ -3,10 +3,13 @@ import {defineComponent} from 'vue';
 
 import * as vscode from '../../../vscode';
 import {state as globalState} from '../state';
+import EDATargetSelector from './EDATargetSelector.vue';
+import type { TargetConfiguration } from 'edacation';
 
 export default defineComponent({
-    components: {},
-    computed: {},
+    components: {
+        EDATargetSelector
+    },
     data() {
         return {
             state: globalState
@@ -14,23 +17,36 @@ export default defineComponent({
     },
     methods: {
         executeCommand(command: string) {
+            console.log(this.selectedTarget);
+
             vscode.vscode.postMessage({
                 type: 'command',
                 command: `edacation.${command}`
             });
+        },
+    },
+    computed: {
+        targets(): TargetConfiguration[] {
+            return this.state.project?.configuration.targets ?? [];
+        },
+
+        selectedTarget(): TargetConfiguration | null {
+            return this.targets[this.state.selectedTargetIndex] ?? null;
         },
     }
 });
 </script>
 
 <template>
-    <div style="flex-direction: row; align-items: stretch">
-        <vscode-button style="margin: 0.5rem" @click="executeCommand('openProjectConfiguration')">
+    <div style="display: flex; flex-direction: column; align-items: stretch; gap: 0.75rem; margin: 0.5rem">
+        <vscode-button @click="executeCommand('openProjectConfiguration')">
             Open Project Configuration
         </vscode-button>
-        <vscode-button style="margin: 0.5rem" @click="executeCommand('runRTL')">Show RTL</vscode-button>
-        <vscode-button style="margin: 0.5rem" @click="executeCommand('runYosys')">Synthesize using Yosys</vscode-button>
-        <vscode-button style="margin: 0.5rem" @click="executeCommand('runNextpnr')">Place and Route using nextpnr</vscode-button>
+        <vscode-divider></vscode-divider>
+        <EDATargetSelector v-if="targets.length > 1"/>
+        <vscode-button @click="executeCommand('runRTL')">Show RTL</vscode-button>
+        <vscode-button @click="executeCommand('runYosys')">Synthesize using Yosys</vscode-button>
+        <vscode-button @click="executeCommand('runNextpnr')">Place and Route using nextpnr</vscode-button>
     </div>
 </template>
 

--- a/src/views/actions/src/components/EDAProjectActions.vue
+++ b/src/views/actions/src/components/EDAProjectActions.vue
@@ -42,11 +42,15 @@ export default defineComponent({
         <vscode-button @click="executeCommand('openProjectConfiguration')">
             Open Project Configuration
         </vscode-button>
-        <vscode-divider></vscode-divider>
-        <EDATargetSelector v-if="targets.length > 1"/>
-        <vscode-button @click="executeCommand('runRTL')">Show RTL</vscode-button>
-        <vscode-button @click="executeCommand('runYosys')">Synthesize using Yosys</vscode-button>
-        <vscode-button @click="executeCommand('runNextpnr')">Place and Route using nextpnr</vscode-button>
+
+        <template v-if="targets.length !== 0">
+            <vscode-divider></vscode-divider>
+            <EDATargetSelector v-if="targets.length > 1"/>
+
+            <vscode-button @click="executeCommand('runRTL')">Show RTL</vscode-button>
+            <vscode-button @click="executeCommand('runYosys')">Synthesize using Yosys</vscode-button>
+            <vscode-button @click="executeCommand('runNextpnr')">Place and Route using nextpnr</vscode-button>
+        </template>
     </div>
 </template>
 

--- a/src/views/actions/src/components/EDATargetSelector.vue
+++ b/src/views/actions/src/components/EDATargetSelector.vue
@@ -1,0 +1,43 @@
+<script lang="ts">
+import {defineComponent} from 'vue';
+import {type TargetConfiguration} from 'edacation';
+import { Dropdown } from '@vscode/webview-ui-toolkit';
+
+import {state as globalState} from '../state';
+
+export default defineComponent({
+    props: {
+        targetIndex: {
+            type: Number
+        }
+    },
+    data() {
+        return {
+            state: globalState
+        };
+    },
+    methods: {
+        handleTargetChange(event: Event) {
+            if (!event.target) return;
+
+            this.state.selectedTargetIndex = (event.target as Dropdown).selectedIndex;
+            console.log(this.state.selectedTargetIndex);
+        }
+    },
+    computed: {
+        targets(): TargetConfiguration[] {
+            return this.state.project?.configuration.targets ?? [];
+        }
+    }
+});
+</script>
+
+<template>
+    <vscode-dropdown @change="handleTargetChange">
+        <vscode-option v-for="(target, index) in targets" :selected="index === state.selectedTargetIndex">
+            {{ target.name }}
+        </vscode-option>
+    </vscode-dropdown>
+</template>
+
+<style scoped></style>

--- a/src/views/actions/src/state/index.ts
+++ b/src/views/actions/src/state/index.ts
@@ -5,14 +5,12 @@ import {vscode} from '../../../vscode';
 
 export interface State {
     project?: ProjectState;
-    selectedTargetIndex: string;
-    selectedTargetTabId: string;
+    selectedTargetIndex: number;
 }
 
 export const DEFAULT_STATE = {
     project: undefined,
-    selectedTargetIndex: 'all',
-    selectedTargetTabId: 'tab-device'
+    selectedTargetIndex: 0
 };
 
 export let state = reactive<State>(DEFAULT_STATE);


### PR DESCRIPTION
Adds a target selector to the project actions menu. The selector is not shown if only a single target is configured.

| 0 targets | 1 target | > 1 targets |
|-------------|------------|----------------|
| ![image](https://github.com/user-attachments/assets/329c395e-a229-4874-aecb-5ef3e58aedc7) | ![image](https://github.com/user-attachments/assets/f9651f8b-21ad-4354-9d6c-c5710ca0b9c9) | ![image](https://github.com/user-attachments/assets/39654c40-d8c2-4120-92bb-6ae1cf9b6d69) |

Fixes #13 
