### PR TITLE
feat: context-aware nextpnr viewer

### DIFF
--- a/src/extension/tasks/rtl.ts
+++ b/src/extension/tasks/rtl.ts
@@ -80,8 +80,8 @@ class RTLTerminalTask extends BaseYosysTerminalTask {
         await vscode.workspace.fs.writeFile(uri, newContent);
     }
 
-    async handleEnd(project: Project, outputFiles: TaskOutputFile[]) {
-        await super.handleEnd(project, outputFiles);
+    async handleEnd(project: Project, workerOptions: YosysWorkerOptions, outputFiles: TaskOutputFile[]) {
+        await super.handleEnd(project, workerOptions, outputFiles);
 
         this.println('Updating output files...');
         await Promise.all(

--- a/src/extension/tasks/task.ts
+++ b/src/extension/tasks/task.ts
@@ -70,9 +70,9 @@ export abstract class TerminalTask<WorkerOptions extends _WorkerOptions> extends
 
     abstract handleStart(project: Project): Promise<void>;
 
-    abstract handleEnd(project: Project, outputFiles: TaskOutputFile[]): Promise<void>;
+    abstract handleEnd(project: Project, workerOptions: WorkerOptions, outputFiles: TaskOutputFile[]): Promise<void>;
 
-    async execute(project: Project, targetId: string) {
+    async execute(project: Project, targetId: string): Promise<WorkerOptions> {
         const workerOptions = this.getWorkerOptions(project, targetId);
 
         const command = this.getInputCommand(workerOptions);
@@ -114,6 +114,8 @@ export abstract class TerminalTask<WorkerOptions extends _WorkerOptions> extends
         this.println();
 
         await this.toolProvider.execute();
+
+        return workerOptions;
     }
 
     cleanup() {

--- a/src/extension/tasks/yosys.ts
+++ b/src/extension/tasks/yosys.ts
@@ -61,7 +61,7 @@ export abstract class BaseYosysTerminalTask extends TerminalTask<YosysWorkerOpti
         this.println();
     }
 
-    async handleEnd(project: Project, _outputFiles: TaskOutputFile[]) {
+    async handleEnd(project: Project, _workerOptions: YosysWorkerOptions, _outputFiles: TaskOutputFile[]) {
         this.println();
         this.println(
             `Finished synthesizing EDA project "${project.getName()}" using Yosys.`,
@@ -131,8 +131,8 @@ class YosysPrepareTerminalTask extends BaseYosysTerminalTask {
         return record;
     }
 
-    async handleEnd(project: Project, outputFiles: TaskOutputFile[]) {
-        await super.handleEnd(project, outputFiles);
+    async handleEnd(project: Project, workerOptions: YosysWorkerOptions, outputFiles: TaskOutputFile[]) {
+        await super.handleEnd(project, workerOptions, outputFiles);
 
         const presynthFile = outputFiles.find((file) => file.path.endsWith('presynth.yosys.json'));
         if (!presynthFile || !presynthFile.uri) return;
@@ -163,8 +163,8 @@ class YosysSynthTerminalTask extends BaseYosysTerminalTask {
         return workerOptions.outputFiles.map((path) => ({type: 'artifact', path}));
     }
 
-    async handleEnd(project: Project, outputFiles: TaskOutputFile[]) {
-        await super.handleEnd(project, outputFiles);
+    async handleEnd(project: Project, workerOptions: YosysWorkerOptions, outputFiles: TaskOutputFile[]) {
+        await super.handleEnd(project, workerOptions, outputFiles);
 
         // Find LUT file
         const lutFile = outputFiles.find((file) => file.path.endsWith('luts.yosys.json'));


### PR DESCRIPTION
Closes #95 

Nextpnr viewer now selects the correct chip details when viewing a file, which fixes ECP5 45k and 85k support. This is achieved by modifying the file format for `routed.nextpnr.json` files. Old files should still be supported and will default to ECP5 25k.