### PR TITLE
VHDL support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@vscode/codicons": "^0.0.36",
                 "@vscode/webview-ui-toolkit": "^1.3.1",
                 "digitaljs": "github:EDAcation/digitaljs#next",
-                "edacation": "^0.3.9",
+                "edacation": "^0.3.10",
                 "nextpnr-viewer": "^0.6.1",
                 "os-browserify": "^0.3.0",
                 "path-browserify": "^1.0.1",
@@ -2384,9 +2384,9 @@
             "dev": true
         },
         "node_modules/edacation": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/edacation/-/edacation-0.3.9.tgz",
-            "integrity": "sha512-bqoDd+ni8nlBveEKqx/rdBX9Rn3hJXzNUWJjWllo9JAgIMYyDj/wzqW64ysopfQyWl5WyU88obEsRsvrCgbo3w==",
+            "version": "0.3.10",
+            "resolved": "https://registry.npmjs.org/edacation/-/edacation-0.3.10.tgz",
+            "integrity": "sha512-OwZDKN3QXQvuFOWUZwep5zyySzckLM1HURgAfANjJWLJYNCXC4DbbCk+RN9s/56AIJVqbNvY8vDFB3wpCbtKpQ==",
             "dependencies": {
                 "string-args-parser": "^1.0.4",
                 "yargs": "^17.7.2",

--- a/package.json
+++ b/package.json
@@ -415,7 +415,7 @@
         "@vscode/codicons": "^0.0.36",
         "@vscode/webview-ui-toolkit": "^1.3.1",
         "digitaljs": "github:EDAcation/digitaljs#next",
-        "edacation": "^0.3.9",
+        "edacation": "^0.3.10",
         "nextpnr-viewer": "^0.6.1",
         "os-browserify": "^0.3.0",
         "path-browserify": "^1.0.1",

--- a/src/extension/projects/project.ts
+++ b/src/extension/projects/project.ts
@@ -192,6 +192,21 @@ export class Project extends BaseProject {
         if (doSave) await this.save();
     }
 
+    async setTopLevelModule(targetId: string, module: string) {
+        const target = this.getTarget(targetId);
+        if (!target) throw new Error(`Target "${targetId} does not exist!`);
+
+        // Ensure the config tree exists
+        // We don't care about setting missing defaults, as this is target-level configuration,
+        // so any missing properties will fallback to project-level config.
+        if (!target.yosys) target.yosys = {};
+        if (!target.yosys.options) target.yosys.options = {};
+
+        target.yosys.options.topLevelModule = module;
+
+        await this.save();
+    }
+
     async removeInputFiles(filePaths: string[]): Promise<void> {
         if (!filePaths.length) return;
 

--- a/src/extension/types.ts
+++ b/src/extension/types.ts
@@ -32,6 +32,12 @@ interface ViewMessageCommand {
     args?: [];
 }
 
+interface ViewMessageChangeTLM {
+    type: 'changeTlm';
+    module: string;
+    targetId: string;
+}
+
 interface ViewMessageRequestSave {
     type: 'requestSave';
     data: {
@@ -44,6 +50,7 @@ interface ViewMessageRequestSave {
 export type ViewMessage =
     | ViewMessageReady
     | ViewMessageCommand
+    | ViewMessageChangeTLM
     | ViewMessageChange
     | MessageBroadcast
     | ViewMessageRequestSave;

--- a/src/extension/util.ts
+++ b/src/extension/util.ts
@@ -1,3 +1,4 @@
+import {FILE_EXTENSIONS_HDL} from 'edacation';
 import path from 'path';
 import * as vscode from 'vscode';
 
@@ -52,12 +53,9 @@ export const encodeJSON = (input: unknown, pretty = false) =>
 export const decodeText = (input: BufferSource): string => textDecoder.decode(input);
 export const decodeJSON = (input: BufferSource): unknown => JSON.parse(decodeText(input));
 
-export const FILE_EXTENSIONS_VERILOG = ['v', 'vh', 'sv', 'svh'];
-export const FILE_EXTENSIONS_VHDL = ['vhd'];
-
 export const FILE_FILTERS_HDL = {
     /* eslint-disable-next-line @typescript-eslint/naming-convention */
-    'HDL (*.v, *.vh, *.sv, *.svh, *.vhd)': [...FILE_EXTENSIONS_VERILOG, ...FILE_EXTENSIONS_VHDL]
+    'HDL (*.v, *.vh, *.sv, *.svh, *.vhd, *.vhdl)': FILE_EXTENSIONS_HDL
 };
 
 export const asWorkspaceRelativeFolderPath = (folderUri: vscode.Uri) =>

--- a/src/extension/webviews/actions.ts
+++ b/src/extension/webviews/actions.ts
@@ -53,11 +53,20 @@ export class ActionsProvider extends BaseWebviewViewProvider {
 
             console.log('[actions]', 'ready project', project.getUri());
 
-            if (project) {
-                await webview.postMessage({
-                    type: 'project',
-                    project: Project.serialize(project)
-                });
+            await webview.postMessage({
+                type: 'project',
+                project: Project.serialize(project)
+            });
+        } else if (message.type === 'changeTlm') {
+            const project = this.projects.getCurrent();
+            if (!project) return;
+
+            console.log('[actions] updating TLM');
+
+            try {
+                await project.setTopLevelModule(message.targetId, message.module);
+            } catch (err) {
+                console.log(`[actions] Error while updating TLM: ${err}`);
             }
         } else if (message.type === 'command') {
             await vscode.commands.executeCommand(message.command, ...(message.args ?? []));

--- a/src/views/actions/src/App.vue
+++ b/src/views/actions/src/App.vue
@@ -1,12 +1,25 @@
 <script lang="ts">
-import {provideVSCodeDesignSystem, vsCodeButton, vsCodeDivider, vsCodeDropdown, vsCodeOption} from '@vscode/webview-ui-toolkit';
+import {
+    provideVSCodeDesignSystem,
+    vsCodeButton,
+    vsCodeDivider,
+    vsCodeDropdown,
+    vsCodeOption,
+    vsCodeTextField
+} from '@vscode/webview-ui-toolkit';
 
 import {vscode} from '../../vscode';
 
 import EDAProjectActions from './components/EDAProjectActions.vue';
 import {state} from './state';
 
-provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeDropdown(), vsCodeOption(), vsCodeDivider());
+provideVSCodeDesignSystem().register(
+    vsCodeButton(),
+    vsCodeDropdown(),
+    vsCodeOption(),
+    vsCodeDivider(),
+    vsCodeTextField()
+);
 
 export default {
     components: {

--- a/src/views/actions/src/components/EDAProjectActions.vue
+++ b/src/views/actions/src/components/EDAProjectActions.vue
@@ -1,14 +1,17 @@
 <script lang="ts">
+import type {TargetConfiguration} from 'edacation';
 import {defineComponent} from 'vue';
 
 import * as vscode from '../../../vscode';
 import {state as globalState} from '../state';
+
 import EDATargetSelector from './EDATargetSelector.vue';
-import type { TargetConfiguration } from 'edacation';
+import EDATargetTLM from './EDATargetTLM.vue';
 
 export default defineComponent({
     components: {
-        EDATargetSelector
+        EDATargetSelector,
+        EDATargetTLM
     },
     data() {
         return {
@@ -30,7 +33,7 @@ export default defineComponent({
             if (!this.selectedTarget) {
                 return this.executeCommand(command);
             }
-            return this.executeCommand(command, this.selectedTarget.id)
+            return this.executeCommand(command, this.selectedTarget.id);
         }
     },
     computed: {
@@ -40,20 +43,19 @@ export default defineComponent({
 
         selectedTarget(): TargetConfiguration | null {
             return this.targets[this.state.selectedTargetIndex] ?? null;
-        },
+        }
     }
 });
 </script>
 
 <template>
     <div style="display: flex; flex-direction: column; align-items: stretch; gap: 0.75rem; margin: 0.5rem">
-        <vscode-button @click="executeCommand('openProjectConfiguration')">
-            Open Project Configuration
-        </vscode-button>
+        <vscode-button @click="executeCommand('openProjectConfiguration')"> Open Project Configuration </vscode-button>
 
         <template v-if="targets.length !== 0">
             <vscode-divider></vscode-divider>
-            <EDATargetSelector v-if="targets.length > 1"/>
+            <EDATargetSelector v-if="targets.length > 1" />
+            <EDATargetTLM :targetIndex="state.selectedTargetIndex" />
 
             <vscode-button @click="executeTargetCommand('runRTL')">Show RTL</vscode-button>
             <vscode-button @click="executeTargetCommand('runYosys')">Synthesize using Yosys</vscode-button>

--- a/src/views/actions/src/components/EDATargetTLM.vue
+++ b/src/views/actions/src/components/EDATargetTLM.vue
@@ -58,7 +58,7 @@ export default defineComponent({
 </script>
 
 <template>
-    <vscode-text-field placeholder="automatic" :value="topLevelModule" @input="handleTLMChange">
+    <vscode-text-field placeholder="Automatic (Verilog only)" :value="topLevelModule" @input="handleTLMChange">
         Top-level module
     </vscode-text-field>
 </template>

--- a/src/views/actions/src/components/EDATargetTLM.vue
+++ b/src/views/actions/src/components/EDATargetTLM.vue
@@ -1,0 +1,66 @@
+<script lang="ts">
+import {TextField} from '@vscode/webview-ui-toolkit';
+import {type TargetConfiguration, type YosysOptions, getYosysDefaultOptions, getYosysOptions} from 'edacation';
+import {defineComponent} from 'vue';
+
+import * as vscode from '../../../vscode';
+import {state as globalState} from '../state';
+
+export default defineComponent({
+    props: {
+        targetIndex: {
+            type: Number
+        }
+    },
+    data() {
+        return {
+            state: globalState
+        };
+    },
+    methods: {
+        handleTLMChange(event: Event) {
+            if (!this.target) return;
+
+            const newTlm = (event.target as TextField).currentValue;
+            vscode.vscode.postMessage({
+                type: 'changeTlm',
+                module: newTlm,
+                targetId: this.target.id
+            });
+        }
+    },
+    computed: {
+        target(): TargetConfiguration | null {
+            if (this.targetIndex === undefined) return null;
+
+            const targets = this.state.project?.configuration.targets ?? [];
+            return targets[this.targetIndex] || null;
+        },
+        effectiveOptions(): YosysOptions | null {
+            if (!this.state.project) return null;
+
+            const projectConfig = this.state.project.configuration;
+            const targetId = this.target?.id;
+
+            if (!targetId) {
+                // Default configuration
+                return getYosysDefaultOptions(projectConfig);
+            } else {
+                // Target configuration
+                return getYosysOptions(projectConfig, targetId);
+            }
+        },
+        topLevelModule(): string | null {
+            return this.effectiveOptions?.topLevelModule ?? null;
+        }
+    }
+});
+</script>
+
+<template>
+    <vscode-text-field placeholder="automatic" :value="topLevelModule" @input="handleTLMChange">
+        Top-level module
+    </vscode-text-field>
+</template>
+
+<style scoped></style>

--- a/src/views/project/src/components/EDATargetSynthesis.vue
+++ b/src/views/project/src/components/EDATargetSynthesis.vue
@@ -1,16 +1,34 @@
 <script lang="ts">
+import type {TargetConfiguration} from 'edacation';
 import {defineComponent} from 'vue';
 
+import {state as globalState} from '../state';
+
 import EDATargetCheckbox from './EDATargetCheckbox.vue';
+import EDATargetTextfield from './EDATargetTextfield.vue';
 
 export default defineComponent({
     components: {
-        EDATargetCheckbox
+        EDATargetCheckbox,
+        EDATargetTextfield
     },
     props: {
         targetIndex: {
             type: Number
         }
+    },
+    computed: {
+        target(): TargetConfiguration | undefined {
+            if (this.targetIndex === undefined) {
+                return undefined;
+            }
+            return this.state.project!.configuration.targets[this.targetIndex];
+        }
+    },
+    data() {
+        return {
+            state: globalState
+        };
     }
 });
 </script>
@@ -22,6 +40,13 @@ export default defineComponent({
             workerId="yosys"
             configId="optimize"
             configName="Enable Yosys optimization"
+        />
+
+        <EDATargetTextfield
+            :targetIndex="targetIndex"
+            workerId="yosys"
+            configId="topLevelModule"
+            configName="Top-level module name"
         />
     </div>
 </template>

--- a/src/views/project/src/components/EDATargetSynthesis.vue
+++ b/src/views/project/src/components/EDATargetSynthesis.vue
@@ -47,6 +47,7 @@ export default defineComponent({
             workerId="yosys"
             configId="topLevelModule"
             configName="Top-level module name"
+            placeholder="Automatic (Verilog only)"
         />
     </div>
 </template>

--- a/src/views/project/src/components/EDATargetTextfield.vue
+++ b/src/views/project/src/components/EDATargetTextfield.vue
@@ -1,0 +1,136 @@
+<script lang="ts">
+import type {TextField} from '@vscode/webview-ui-toolkit';
+import {
+    type NextpnrConfiguration,
+    type NextpnrOptions,
+    type NextpnrTargetConfiguration,
+    type TargetConfiguration,
+    type WorkerId,
+    type YosysConfiguration,
+    type YosysOptions,
+    type YosysTargetConfiguration,
+    getNextpnrDefaultOptions,
+    getNextpnrOptions,
+    getYosysDefaultOptions,
+    getYosysOptions
+} from 'edacation';
+import {type PropType, defineComponent} from 'vue';
+
+import {state as globalState} from '../state';
+
+export default defineComponent({
+    props: {
+        targetIndex: {
+            type: Number
+        },
+        workerId: {
+            type: String as PropType<'yosys' | 'nextpnr'>,
+            required: true
+        },
+        configId: {
+            type: String as PropType<keyof YosysOptions | keyof NextpnrOptions>,
+            required: true
+        },
+        configName: {
+            type: String,
+            required: true
+        }
+    },
+    data() {
+        return {
+            state: globalState
+        };
+    },
+    computed: {
+        target(): TargetConfiguration | undefined {
+            if (this.targetIndex === undefined) {
+                return undefined;
+            }
+            return this.state.project!.configuration.targets[this.targetIndex];
+        },
+        defaultWorker(): YosysConfiguration | NextpnrConfiguration | undefined {
+            if (!this.state.project!.configuration.defaults) {
+                return undefined;
+            }
+            return this.state.project!.configuration.defaults[this.workerId as WorkerId];
+        },
+        worker():
+            | YosysConfiguration
+            | YosysTargetConfiguration
+            | NextpnrConfiguration
+            | NextpnrTargetConfiguration
+            | undefined {
+            return this.target ? this.target[this.workerId as WorkerId] : this.defaultWorker;
+        },
+        options() {
+            if (!this.worker) {
+                return undefined;
+            }
+            return this.worker.options;
+        },
+        effectiveOptions(): YosysOptions | NextpnrOptions | null {
+            const projectConfig = this.state.project!.configuration;
+            const targetId = this.target?.id;
+
+            if (!targetId) {
+                // Default configuration
+                if (this.workerId === 'yosys') return getYosysDefaultOptions(projectConfig);
+                if (this.workerId === 'nextpnr') return getNextpnrDefaultOptions(projectConfig);
+                return null;
+            } else {
+                // Target configuration
+                if (this.workerId === 'yosys') return getYosysOptions(projectConfig, targetId);
+                if (this.workerId === 'nextpnr') return getNextpnrOptions(projectConfig, targetId);
+                return null;
+            }
+        },
+        effectiveConfig(): string | undefined {
+            if (!this.effectiveOptions) {
+                return undefined;
+            }
+            return this.effectiveOptions[this.configId as keyof typeof this.effectiveOptions];
+        }
+    },
+    methods: {
+        ensureConfig() {
+            if (!this.state.project) {
+                return false;
+            }
+
+            if (!this.options) {
+                if (!this.worker) {
+                    if (this.target) {
+                        this.target[this.workerId as WorkerId] = {};
+                    } else {
+                        if (!this.state.project.configuration.defaults) {
+                            this.state.project.configuration.defaults = {};
+                        }
+                        this.state.project.configuration.defaults[this.workerId as WorkerId] = {};
+                    }
+                }
+
+                this.worker!.options = {};
+            }
+
+            return true;
+        },
+
+        handleTextfieldChange(event: Event) {
+            if (!event.target || !this.ensureConfig()) {
+                return;
+            }
+
+            (this.options as Record<string, string | undefined>)[this.configId] =
+                (event.target as TextField).currentValue || undefined;
+        }
+    }
+});
+</script>
+
+<template>
+    <div>
+        <vscode-text-field placeholder="automatic" :value="effectiveConfig" @input="handleTextfieldChange">
+            {{ configName }}
+        </vscode-text-field>
+    </div>
+</template>

--- a/src/views/project/src/components/EDATargetTextfield.vue
+++ b/src/views/project/src/components/EDATargetTextfield.vue
@@ -34,6 +34,10 @@ export default defineComponent({
         configName: {
             type: String,
             required: true
+        },
+        placeholder: {
+            type: String,
+            required: false
         }
     },
     data() {
@@ -129,7 +133,7 @@ export default defineComponent({
 
 <template>
     <div>
-        <vscode-text-field placeholder="automatic" :value="effectiveConfig" @input="handleTextfieldChange">
+        <vscode-text-field :placeholder="placeholder" :value="effectiveConfig" @input="handleTextfieldChange">
             {{ configName }}
         </vscode-text-field>
     </div>

--- a/src/views/project/src/components/EDATargetYosys.vue
+++ b/src/views/project/src/components/EDATargetYosys.vue
@@ -4,6 +4,7 @@ import type {TargetConfiguration, YosysConfiguration, YosysTargetConfiguration} 
 import {defineComponent} from 'vue';
 
 import {state as globalState} from '../state';
+import type {PotentialError} from '../util';
 
 import EDATargetValueList from './EDATargetValueList.vue';
 
@@ -28,14 +29,26 @@ export default defineComponent({
             console.log('yosys target', this.target, this.targetIndex, yosys, yosys ?? {});
             return yosys ?? {};
         },
-        generated(): ReturnType<typeof generateYosysWorkerOptions> | null {
-            if (!this.target) return null;
+        generated(): PotentialError<ReturnType<typeof generateYosysWorkerOptions> | null> {
+            if (!this.target || !this.state.project) return {status: 'ok', res: null};
 
-            return generateYosysWorkerOptions(
-                this.state.project!.configuration,
-                this.state.project!.inputFiles,
-                this.target.id
-            );
+            try {
+                const options = generateYosysWorkerOptions(
+                    this.state.project.configuration,
+                    this.state.project.inputFiles,
+                    this.target.id
+                );
+                return {status: 'ok', res: options};
+            } catch (err: any) {
+                console.trace(`Error generating Yosys worker options: ${err}`);
+                return {status: 'error', err: err as Error};
+            }
+        },
+        generatedError(): Error | null {
+            return this.generated.status === 'error' ? this.generated.err : null;
+        },
+        generatedOptions(): ReturnType<typeof generateYosysWorkerOptions> | null {
+            return this.generated.status === 'ok' ? this.generated.res : null;
         }
     },
     data() {
@@ -49,9 +62,10 @@ export default defineComponent({
 <template>
     <template v-if="yosys">
         <div style="width: 100%; display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem">
+            <code v-if="generatedError" style="color: red; grid-column: span 2">{{ generatedError }}</code>
             <EDATargetValueList
                 :targetIndex="targetIndex"
-                :generated="generated?.commands ?? []"
+                :generated="generatedOptions?.commands ?? []"
                 workerId="yosys"
                 workerName="Yosys"
                 configId="commands"
@@ -63,7 +77,7 @@ export default defineComponent({
 
             <EDATargetValueList
                 :targetIndex="targetIndex"
-                :generated="generated?.inputFiles ?? []"
+                :generated="generatedOptions?.inputFiles ?? []"
                 workerId="yosys"
                 workerName="Yosys"
                 configId="inputFiles"
@@ -76,7 +90,7 @@ export default defineComponent({
 
             <EDATargetValueList
                 :targetIndex="targetIndex"
-                :generated="generated?.outputFiles ?? []"
+                :generated="generatedOptions?.outputFiles ?? []"
                 workerId="yosys"
                 workerName="Yosys"
                 configId="outputFiles"

--- a/src/views/project/src/util.ts
+++ b/src/views/project/src/util.ts
@@ -2,6 +2,8 @@ export type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType exten
     ? ElementType
     : never;
 
+export type PotentialError<WorkerOptions> = {status: 'ok'; res: WorkerOptions} | {status: 'error'; err: Error};
+
 export const keysForEnum = <M extends Record<string, unknown>>(map: M): [keyof M, ...(keyof M)[]] =>
     Object.keys(map) as unknown as [keyof M, ...(keyof M)[]];
 


### PR DESCRIPTION
Closes #109 

Synthesizing VHDL requires the top-level module to be manually supplied by the user, which can be done either in the project settings (under the `Synthesis` tab) or directly in the actions sidebar. This setting is target-specific.

I personally quite dislike having a text input field in the actions sidebar, so in the long term we might want to consider replacing it with a dropdown. This dropdown could be filled by statically analyzing the verilog/VHDL input files, using e.g. tree-sitter.
