### PR TITLE
fix: nextpnr viewer issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@vue/tsconfig": "^0.8.1",
                 "digitaljs": "github:EDAcation/digitaljs#next",
                 "edacation": "^0.6.4",
-                "nextpnr-viewer": "^0.9.2",
+                "nextpnr-viewer": "^0.9.3",
                 "os-browserify": "^0.3.0",
                 "path-browserify-win32": "^2.0.1",
                 "tar-fs": "^3.1.1",
@@ -4218,9 +4218,9 @@
             "license": "MIT"
         },
         "node_modules/nextpnr-viewer": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/nextpnr-viewer/-/nextpnr-viewer-0.9.2.tgz",
-            "integrity": "sha512-ZV4ijwQJE+NKeC2xsHpJNold3DBLTQeKyq0JcoOINiHsb7cbkH9njlM32r3hU0CuVt/fXNO1oaKPbEIWTUi94A==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/nextpnr-viewer/-/nextpnr-viewer-0.9.3.tgz",
+            "integrity": "sha512-NSELf8EImxBy7hlJ72zTFdrBAgXNYVzwrfYWhK5srypjxQYIq7ZbwjhrUDUWUtfszjGsbSeRAE7UR95Rszq0CA==",
             "license": "MIT"
         },
         "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -440,7 +440,7 @@
     },
     "scripts": {
         "postinstall": "sed -i \"s/require('topsort');/require('topsort').default;/\" node_modules/yosys2digitaljs/dist/index.js",
-        "run-in-browser": "vscode-test-web --browserType=none --extensionDevelopmentPath=. .",
+        "run-in-browser": "vscode-test-web --browserType=none --extensionDevelopmentPath=. ../example-project",
         "watch-web": "webpack --watch",
         "compile-web": "tsc && webpack",
         "package-web": "webpack --mode production --devtool hidden-source-map",
@@ -483,7 +483,7 @@
         "@vue/tsconfig": "^0.8.1",
         "digitaljs": "github:EDAcation/digitaljs#next",
         "edacation": "^0.6.4",
-        "nextpnr-viewer": "^0.9.2",
+        "nextpnr-viewer": "^0.9.3",
         "os-browserify": "^0.3.0",
         "path-browserify-win32": "^2.0.1",
         "tar-fs": "^3.1.1",

--- a/src/views/nextpnr/main.ts
+++ b/src/views/nextpnr/main.ts
@@ -1,7 +1,14 @@
 import '@vscode-elements/elements';
 import '@vscode/codicons/dist/codicon.css';
 import {getElementGroups} from 'edacation';
-import {NextPNRViewer, SUPPORTED_DEVICES, type SupportedChip, isSupported} from 'nextpnr-viewer';
+import {
+    NextPNRViewer,
+    type NextpnrJson,
+    type ReportJson,
+    SUPPORTED_DEVICES,
+    type SupportedChip,
+    isSupported
+} from 'nextpnr-viewer';
 
 import {vscode} from '../vscode-wrapper';
 
@@ -18,14 +25,10 @@ interface MessageDocument {
 
 type Message = MessageDocument;
 
-interface NextpnrJSON {
-    creator: string;
-    modules: unknown;
-}
-
 interface NextpnrFileFormat {
     chip: SupportedChip;
-    data: NextpnrJSON;
+    report?: ReportJson;
+    data: NextpnrJson;
 }
 
 class View {
@@ -118,13 +121,13 @@ class View {
             }
 
             // Parse nextpnr document from JSON string
-            // Support old file format as well (raw NextpnrJSON)
-            const json = JSON.parse(this.state.document) as NextpnrFileFormat | NextpnrJSON;
+            // Support old file format as well (raw NextpnrJson)
+            const json = JSON.parse(this.state.document) as NextpnrFileFormat | NextpnrJson;
 
             // Deduce exact chip to render
             let chip: {family: string; device: string};
-            let data: NextpnrJSON;
-            let report: unknown;
+            let data: NextpnrJson;
+            let report: ReportJson | undefined = undefined;
             if ('chip' in json) {
                 chip = json.chip;
                 data = json.data;
@@ -174,7 +177,7 @@ class View {
 
             // Render nextpnr document
             const viewer = this.viewer;
-            void viewer.showJson(JSON.stringify(data), JSON.stringify(report)).then(() => {
+            void viewer.showJson(data, report).then(() => {
                 // Delay first render until after showJson is called, this allows for internal optimizations
                 void viewer.render();
             });


### PR DESCRIPTION
Some people were running into issues where the nextpnr viewer wouldn't load. `fetch()` would always timeout, so the worker couldn't load any resources. this update makes it so that resources are downloaded in the main thread and then passed on to the worker thread.
